### PR TITLE
allow user to define entire URL

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -23,7 +23,7 @@ return [
     'github' => [
         'client_id' => env('GITHUB_CLIENT_ID'),
         'client_secret' => env('GITHUB_CLIENT_SECRET'),
-        'redirect' => 'http://'.env('APP_URL').'/auth/github/callback',
+        'redirect' => env('APP_URL').'/auth/github/callback',
     ],
 
 ];


### PR DESCRIPTION
The reason for this is cause I needed to use SSL. And without it you dont support https.